### PR TITLE
Remove deprecated sklearn from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ progressbar
 pyarrow
 scikit-learn 
 scipy
-sklearn
 torch


### PR DESCRIPTION
The package named `sklearn` has been deprecated and replaced by `scikit-learn` which is already in the list of dependencies. This PR removes the deprecated name.